### PR TITLE
To better line up the output, I added some changes

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,14 +1,19 @@
 package slogcolor
 
 import (
+	"github.com/fatih/color"
 	"log/slog"
 	"time"
 )
 
 var DefaultOptions *Options = &Options{
-	Level:       slog.LevelInfo,
-	TimeFormat:  time.DateTime,
-	SrcFileMode: ShortFile,
+	Level:         slog.LevelInfo,
+	TimeFormat:    time.DateTime,
+	SrcFileMode:   ShortFile,
+	SrcFileLength: 0,
+	MsgPrefix:     color.HiWhiteString("| "),
+	MsgLength:     0,
+	MsgColor:      color.New(),
 }
 
 type Options struct {
@@ -22,4 +27,16 @@ type Options struct {
 
 	// SrcFileMode is the source file mode.
 	SrcFileMode SourceFileMode
+
+	// SrcFileLength to show fixed length filename to line up the log output, default 0 shows complete filename
+	SrcFileLength int
+
+	// MsgPrefix to show prefix before message, default: white colored "| "
+	MsgPrefix string
+
+	// MsgColor is the color of the message, default to empty
+	MsgColor *color.Color
+
+	// MsgLength to show fixed length message to line up the log output, default 0 shows complete message
+	MsgLength int
 }


### PR DESCRIPTION
* the filename can have a fixed length, if the name is below the fixed length, it is filled up with spaces, if its over the fixed length, it is truncated
* the message can have a fixed length, if the name is below the fixed length, it is filled up with spaces, if its over the fixed length, it is truncated
* specify the msg prefix separator (I saw that prefix.go is not used)
* specify the msg color, to better highlight it

The PR should be backwards compatible, if the new options are not set it looks as before.

![image](https://github.com/MatusOllah/slogcolor/assets/1283564/fb9b209f-41b9-4dd9-969a-9541182156cd)
