### PR TITLE
[feat] add support for custom level tags

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -8,13 +8,18 @@ import (
 	"time"
 
 	"github.com/MatusOllah/slogcolor"
+	"github.com/fatih/color"
 )
 
 func Example() {
 	opts := slogcolor.DefaultOptions
 	opts.Level = slog.LevelDebug
-	slog.SetDefault(slog.New(slogcolor.NewHandler(os.Stderr, opts)))
 
+	opts.LevelTags = map[slog.Level]string{
+		slog.LevelInfo: color.New(color.BgCyan, color.FgBlack).Sprint("Info"),
+	}
+
+	slog.SetDefault(slog.New(slogcolor.NewHandler(os.Stderr, opts)))
 	slog.Info("Initializing")
 	slog.Debug("Init done", "duration", 500*time.Millisecond)
 	slog.Warn("Slow request!", "method", "GET", "path", "/api/users", "duration", 750*time.Millisecond)

--- a/options.go
+++ b/options.go
@@ -7,6 +7,13 @@ import (
 	"github.com/fatih/color"
 )
 
+var DefaultLevelTags = &map[slog.Level]string{
+	slog.LevelDebug: color.New(color.BgCyan, color.FgHiWhite).Sprint("DEBUG"),
+	slog.LevelInfo:  color.New(color.BgGreen, color.FgHiWhite).Sprint("INFO"),
+	slog.LevelWarn:  color.New(color.BgYellow, color.FgHiWhite).Sprint("WARN"),
+	slog.LevelError: color.New(color.BgRed, color.FgHiWhite).Sprint("ERROR"),
+}
+
 var DefaultOptions *Options = &Options{
 	Level:         slog.LevelInfo,
 	TimeFormat:    time.DateTime,
@@ -44,4 +51,7 @@ type Options struct {
 
 	// NoColor disables color, default: false.
 	NoColor bool
+
+	// LevelTags is level tag for message, default: DefaultLevelStyles
+	LevelTags map[slog.Level]string
 }


### PR DESCRIPTION
This PR adds the ability to customize log level tags via a new `Options.LevelTags` map.

- Introduced `DefaultLevelTags` with existing styles.
- Merged user-defined tags with defaults in `NewHandler`.
- Replaced hardcoded `switch` with `opts.LevelTags[r.Level]`.
- Updated test example to show usage.

Closes #3.