### PR TITLE
Add ValueFormatter option.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -15,6 +15,14 @@ import (
 	"github.com/fatih/color"
 )
 
+func formatValue(v slog.Value, formatter func(slog.Value) string) string {
+	if formatter != nil {
+		return formatter(v)
+	}
+
+	return v.String()
+}
+
 // Handler is a colored slog handler.
 type Handler struct {
 	groups []string
@@ -136,9 +144,9 @@ func (h *Handler) Handle(_ context.Context, r slog.Record) error {
 		}
 
 		if strings.Contains(a.Key, "err") {
-			fmt.Fprint(bf, color.New(color.FgRed).Sprintf("%s=", a.Key)+a.Value.String())
+			fmt.Fprint(bf, color.New(color.FgRed).Sprintf("%s=", a.Key)+formatValue(a.Value, h.opts.ValueFormatter))
 		} else {
-			fmt.Fprint(bf, color.New(color.FgCyan).Sprintf("%s=", a.Key)+a.Value.String())
+			fmt.Fprint(bf, color.New(color.FgCyan).Sprintf("%s=", a.Key)+formatValue(a.Value, h.opts.ValueFormatter))
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -62,4 +62,8 @@ type Options struct {
 
 	// LevelTags is level tag for message, default: DefaultLevelStyles
 	LevelTags map[slog.Level]string
+
+	// ValueFormatter formats attribute values before they are written.
+	// If nil, [slog.Value.String] is used.
+	ValueFormatter func(slog.Value) string
 }

--- a/value_formatter_test.go
+++ b/value_formatter_test.go
@@ -1,0 +1,60 @@
+package slogcolor_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SladkyCitron/slogcolor"
+	"github.com/fatih/color"
+)
+
+func TestHandlerUsesCustomValueFormatter(t *testing.T) {
+	var buf bytes.Buffer
+
+	h := slogcolor.NewHandler(&buf, &slogcolor.Options{
+		Level:       slog.LevelDebug,
+		NoColor:     true,
+		NoTime:      true,
+		SrcFileMode: slogcolor.Nop,
+		MsgPrefix:   "",
+		MsgColor:    color.New(),
+		ValueFormatter: func(v slog.Value) string {
+			return "custom(" + v.String() + ")"
+		},
+	})
+
+	logger := slog.New(h)
+	logger.Info("hello", "duration", 1500*time.Millisecond, "count", 7)
+
+	out := buf.String()
+	if !strings.Contains(out, "duration=custom(1.5s)") {
+		t.Fatalf("expected custom formatter output for duration, got: %q", out)
+	}
+	if !strings.Contains(out, "count=custom(7)") {
+		t.Fatalf("expected custom formatter output for int, got: %q", out)
+	}
+}
+
+func TestHandlerUsesDefaultValueFormattingWhenFormatterNil(t *testing.T) {
+	var buf bytes.Buffer
+
+	h := slogcolor.NewHandler(&buf, &slogcolor.Options{
+		Level:       slog.LevelDebug,
+		NoColor:     true,
+		NoTime:      true,
+		SrcFileMode: slogcolor.Nop,
+		MsgPrefix:   "",
+		MsgColor:    color.New(),
+	})
+
+	logger := slog.New(h)
+	logger.Info("hello", "duration", 1500*time.Millisecond)
+
+	out := buf.String()
+	if !strings.Contains(out, "duration=1.5s") {
+		t.Fatalf("expected default value string formatting, got: %q", out)
+	}
+}


### PR DESCRIPTION
The standard value formatter formats groups in ways that are ambiguous, e.g.:
```
memory=[total=32 GiB available=6.81 GiB]
```
It’s clearer to format the values, thus:
```
memory={total="32 GiB" available="6.81 GiB"}
```
This changeset lets applications do that.